### PR TITLE
Add original contest question sets and update question bank

### DIFF
--- a/original_contest_set_1.json
+++ b/original_contest_set_1.json
@@ -1,0 +1,205 @@
+{
+  "name": "Original Contest Set 1",
+  "problems": [
+    {
+      "q": "How many integers from 1 to 2025 (inclusive) are divisible by 9?",
+      "answer": "225",
+      "image": ""
+    },
+    {
+      "q": "Express $\\frac{1}{2} - \\frac{1}{5}$ divided by $\\frac{1}{2} + \\frac{1}{5}$ as a common fraction.",
+      "answer": "$\\frac{3}{7}$",
+      "image": ""
+    },
+    {
+      "q": "It takes 5 workers 8 hours to build a wall. How many hours would it take 4 workers, working at the same rate, to build the same wall?",
+      "answer": "10",
+      "image": ""
+    },
+    {
+      "q": "What is the smallest prime number greater than 200?",
+      "answer": "211",
+      "image": ""
+    },
+    {
+      "q": "If $5x + 8 = 54$, what is the value of $10x + 8$?",
+      "answer": "100",
+      "image": ""
+    },
+    {
+      "q": "In a bag of candies, $\\frac{1}{5}$ are cherry, $\\frac{1}{5}$ are lemon, $\\frac{1}{4}$ are apple, $\\frac{1}{4}$ are grape, and the remaining 10 candies are orange. How many grape candies are in the bag?",
+      "answer": "25",
+      "image": ""
+    },
+    {
+      "q": "How many ordered pairs $(a, b)$ of positive integers satisfy $a + b \\le 6$?",
+      "answer": "15",
+      "image": ""
+    },
+    {
+      "q": "The acute angles of a right triangle are in the ratio $4:5$. What is the degree measure of the smaller acute angle?",
+      "answer": "40",
+      "image": ""
+    },
+    {
+      "q": "The sequence $1, 3, 5, 7, 9, 1, 3, 5, 7, 9, \\dots$ repeats every 5 terms. What is the sum of the 20th term and the 21st term of this sequence?",
+      "answer": "10",
+      "image": ""
+    },
+    {
+      "q": "Three standard six-sided dice are tossed. What is the probability that the sum of the dice is less than 5? Express your answer as a common fraction.",
+      "answer": "$\\frac{1}{54}$",
+      "image": ""
+    },
+    {
+      "q": "The number $\\frac{3}{4}$ is how many percent of $\\frac{5}{6}$?",
+      "answer": "90%",
+      "image": ""
+    },
+    {
+      "q": "Two similar triangles have areas $9$ square units and $16$ square units. If the perimeter of the smaller triangle is $12$ units, what is the perimeter of the larger triangle?",
+      "answer": "16",
+      "image": ""
+    },
+    {
+      "q": "On a distant planet, a year is 360 days long and a week is 7 days long, with the usual day names. If New Year’s Day this year fell on a Sunday, on what day of the week will New Year’s Day fall next year?",
+      "answer": "Wednesday",
+      "image": ""
+    },
+    {
+      "q": "A voice recorder can hold up to 15 minutes of messages. Each message uses at least 20 seconds. What is the greatest number of messages it can hold?",
+      "answer": "45",
+      "image": ""
+    },
+    {
+      "q": "A bowl of trail mix is 48% peanuts, 16% almonds, 16% walnuts, and 20% cashews by weight. If all the cashews are removed, what percent of the remaining mix is peanuts?",
+      "answer": "60%",
+      "image": ""
+    },
+    {
+      "q": "In a school election with 1500 students voting for either A or B, candidate A received 800 votes. How many more votes did A receive than B?",
+      "answer": "100",
+      "image": ""
+    },
+    {
+      "q": "Let $H(x, y) = \\frac{2xy}{x + y}$. What is the value of $H(4, 12)$?",
+      "answer": "6",
+      "image": ""
+    },
+    {
+      "q": "A runner ran $5$ kilometers in $20$ minutes. What was the runner’s average speed in kilometers per hour?",
+      "answer": "15",
+      "image": ""
+    },
+    {
+      "q": "In a school, $\\frac{2}{3}$ of the students study Spanish and $\\frac{1}{4}$ study French, and the remaining 30 students study neither language. No student studies both Spanish and French. How many students study a language?",
+      "answer": "330",
+      "image": ""
+    },
+    {
+      "q": "How many diagonals does a regular octagon have?",
+      "answer": "20",
+      "image": ""
+    },
+    {
+      "q": "What is the largest prime number that divides 8888?",
+      "answer": "101",
+      "image": ""
+    },
+    {
+      "q": "A 12-pack of soda costs $9.00, plus 5% sales tax, plus a $0.10 deposit per can. How much does one 12-pack cost in total, in dollars, to the nearest cent?",
+      "answer": "$10.65$",
+      "image": ""
+    },
+    {
+      "q": "How many whole numbers are there between $\\sqrt{50}$ and $\\sqrt{500}$?",
+      "answer": "15",
+      "image": ""
+    },
+    {
+      "q": "What is the value of $\\frac{5! \\times 7!}{6!}$?",
+      "answer": "840",
+      "image": ""
+    },
+    {
+      "q": "Given that $(x - y)^2 = 55$ and $xy = 36$, what is the value of $(x + y)^2$?",
+      "answer": "199",
+      "image": ""
+    },
+    {
+      "q": "What is the smallest positive integer that is divisible by 7 and whose decimal representation consists of only the digits 0 and 1?",
+      "answer": "1001",
+      "image": ""
+    },
+    {
+      "q": "Given that $\\sqrt{4 + \\sqrt{16 + x}} = 4$, what is the value of $x$?",
+      "answer": "128",
+      "image": ""
+    },
+    {
+      "q": "What is the area, in square cm, of an isosceles triangle with side lengths $7$ cm, $7$ cm, and $2$ cm? Express your answer in simplest radical form.",
+      "answer": "$4\\sqrt{3}$",
+      "image": ""
+    },
+    {
+      "q": "The side lengths of a triangle are in the ratio $3:7:8$. If its perimeter is $180$ cm, how many cm long is the longest side?",
+      "answer": "80",
+      "image": ""
+    },
+    {
+      "q": "Five fair coins are tossed. What is the probability of getting at least one head and at least one tail? Express your answer as a common fraction.",
+      "answer": "$\\frac{15}{16}$",
+      "image": ""
+    },
+    {
+      "q": "What is the units digit of $7^{2025}$?",
+      "answer": "7",
+      "image": ""
+    },
+    {
+      "q": "If $2^{2^6} = 4^n$, what is the value of $n$?",
+      "answer": "32",
+      "image": ""
+    },
+    {
+      "q": "The first term of an arithmetic sequence is 3, and the sum of the first 4 terms is 60. What is the sum of the first 5 terms of the sequence?",
+      "answer": "95",
+      "image": ""
+    },
+    {
+      "q": "A basketball team has 5 wins and 15 losses so far. The team will play 20 more games this season. To finish with at least a 50% win record, what is the greatest number of these remaining games the team can lose?",
+      "answer": "5",
+      "image": ""
+    },
+    {
+      "q": "How many integer values of $n$ are there such that $\\frac{5}{n} > \\frac{4}{3}$?",
+      "answer": "3",
+      "image": ""
+    },
+    {
+      "q": "The first term of a geometric sequence is 2, and the second term is 6. What is the fifth term?",
+      "answer": "162",
+      "image": ""
+    },
+    {
+      "q": "What is the smallest positive integer $n$ such that $\\text{LCM}(6, 15, n) = 60$?",
+      "answer": "4",
+      "image": ""
+    },
+    {
+      "q": "Alphonse has $\\frac{5}{8}$ as much money as Bettina, and together they have $400. How many dollars does Bettina have?",
+      "answer": "280",
+      "image": ""
+    },
+    {
+      "q": "For what value of $x$ is the average of $10$, $21$, $x$, and $2x$ equal to $35$?",
+      "answer": "33",
+      "image": ""
+    },
+    {
+      "q": "Define $a \\star b = a^2 - b^2$. What is the value of $10 \\star 3$?",
+      "answer": "91",
+      "image": ""
+    }
+  ]
+}

--- a/original_contest_set_2.json
+++ b/original_contest_set_2.json
@@ -1,0 +1,205 @@
+{
+  "name": "Original Contest Set 2",
+  "problems": [
+    {
+      "q": "How many integers between 10 and 250 (inclusive) are multiples of 4?",
+      "answer": "60",
+      "image": ""
+    },
+    {
+      "q": "Compute $\\frac{1}{2} + \\frac{1}{4} + \\frac{1}{8}$. Express your answer as a common fraction.",
+      "answer": "$\\frac{7}{8}$",
+      "image": ""
+    },
+    {
+      "q": "Three people can build a shed in 12 days. How many days would it take 4 people, working at the same rate, to build the same shed?",
+      "answer": "9",
+      "image": ""
+    },
+    {
+      "q": "How many prime numbers are there between 10 and 30 (inclusive)?",
+      "answer": "6",
+      "image": ""
+    },
+    {
+      "q": "If $7x - 5 = 16$, what is the value of $14x - 5$?",
+      "answer": "37",
+      "image": ""
+    },
+    {
+      "q": "In a class, $\\frac{1}{3}$ of the students are in the choir and $\\frac{1}{2}$ are in the band, and the remaining 6 students are in neither group. No student is in both choir and band. How many students are in the class?",
+      "answer": "36",
+      "image": ""
+    },
+    {
+      "q": "How many 3-digit positive integers have all of their digits even?",
+      "answer": "100",
+      "image": ""
+    },
+    {
+      "q": "The three angles of a triangle are in the ratio $2:3:4$. What is the degree measure of the largest angle?",
+      "answer": "80",
+      "image": ""
+    },
+    {
+      "q": "The sequence $1, 2, 3, \\dots, 10, 1, 2, 3, \\dots, 10, \\dots$ repeats the numbers 1 through 10 in order. What is the 68th term of this sequence?",
+      "answer": "8",
+      "image": ""
+    },
+    {
+      "q": "Two fair six-sided dice are rolled. What is the probability that the sum of the two dice is at least 10? Express your answer as a common fraction.",
+      "answer": "$\\frac{1}{6}$",
+      "image": ""
+    },
+    {
+      "q": "The number $\\frac{5}{8}$ is what percent of $\\frac{1}{2}$?",
+      "answer": "125%",
+      "image": ""
+    },
+    {
+      "q": "A rectangle has side lengths 3 cm and 5 cm. A second, larger rectangle is similar to the first and has its longer side length equal to 15 cm. What is the area of the larger rectangle?",
+      "answer": "135",
+      "image": ""
+    },
+    {
+      "q": "If today is Tuesday, what day of the week will it be 100 days from now?",
+      "answer": "Thursday",
+      "image": ""
+    },
+    {
+      "q": "An elevator can carry at most 1000 kilograms. If each person on the elevator weighs at least 65 kilograms, what is the maximum number of people that can safely ride the elevator at one time?",
+      "answer": "15",
+      "image": ""
+    },
+    {
+      "q": "A bag of trail mix is 30% peanuts, 20% almonds, and 50% raisins by weight. If all the raisins are removed, what percent of the remaining mix is peanuts?",
+      "answer": "60%",
+      "image": ""
+    },
+    {
+      "q": "In a school election, there were 1200 total votes cast for either candidate A or candidate B. If candidate A received 700 votes, how many more votes did A receive than B?",
+      "answer": "200",
+      "image": ""
+    },
+    {
+      "q": "Let $F(a, b) = a^2 + a b + b^2$. What is the value of $F(2, 3)$?",
+      "answer": "19",
+      "image": ""
+    },
+    {
+      "q": "A car travels 150 miles in 3 hours. What is its average speed in miles per hour?",
+      "answer": "50",
+      "image": ""
+    },
+    {
+      "q": "In a company, $\\frac{1}{3}$ of the employees work in marketing and $\\frac{1}{4}$ work in sales. The remaining 10 employees work in other departments. (No employee works in both marketing and sales.) How many employees does the company have in total?",
+      "answer": "24",
+      "image": ""
+    },
+    {
+      "q": "How many distinct triangles can be formed by choosing any 3 vertices of a regular octagon?",
+      "answer": "56",
+      "image": ""
+    },
+    {
+      "q": "What is the largest prime factor of 187?",
+      "answer": "17",
+      "image": ""
+    },
+    {
+      "q": "A computer has a list price of $800. During a sale, it is sold at a 15% discount off the list price. If a sales tax of 8% is applied to the discounted price, what is the final price of the computer, in dollars, to the nearest cent?",
+      "answer": "$734.40$",
+      "image": ""
+    },
+    {
+      "q": "How many whole numbers are there between $\\sqrt[3]{100}$ and $\\sqrt[3]{1000}$?",
+      "answer": "5",
+      "image": ""
+    },
+    {
+      "q": "What is the value of $\\frac{8!}{5! \\times 3!}$?",
+      "answer": "56",
+      "image": ""
+    },
+    {
+      "q": "If $x + y = 10$ and $xy = 21$, what is the value of $x^2 + y^2$?",
+      "answer": "58",
+      "image": ""
+    },
+    {
+      "q": "What is the smallest positive integer whose decimal representation consists of only the digit 5 and that is divisible by 3?",
+      "answer": "555",
+      "image": ""
+    },
+    {
+      "q": "Solve for $x$: $\\sqrt{5 + \\sqrt{25 + x}} = 6.$",
+      "answer": "936",
+      "image": ""
+    },
+    {
+      "q": "What is the area of the triangle with vertices at $(0, 0)$, $(6, 0)$, and $(0, 7)$?",
+      "answer": "21",
+      "image": ""
+    },
+    {
+      "q": "The circumference of a circle is $18\\pi$ units. What is the area of the circle?",
+      "answer": "$81\\pi$",
+      "image": ""
+    },
+    {
+      "q": "Four fair coins are tossed. What is the probability of getting exactly two heads? Express your answer as a common fraction.",
+      "answer": "$\\frac{3}{8}$",
+      "image": ""
+    },
+    {
+      "q": "What is the largest perfect cube less than 1000?",
+      "answer": "729",
+      "image": ""
+    },
+    {
+      "q": "If $8^{2^3} = 16^n$, what is $n$?",
+      "answer": "6",
+      "image": ""
+    },
+    {
+      "q": "The first term of an arithmetic sequence is 4, and the sum of the first 5 terms is 100. What is the sum of the first 6 terms?",
+      "answer": "144",
+      "image": ""
+    },
+    {
+      "q": "A student took the same test three times. Each time he retook the test, he answered 25% more questions correctly than in his previous attempt. If he answered 25 questions correctly on his third attempt, how many questions did he answer correctly on his first attempt?",
+      "answer": "16",
+      "image": ""
+    },
+    {
+      "q": "How many integer values of $n$ satisfy the inequality $|n - 5| < 4$?",
+      "answer": "7",
+      "image": ""
+    },
+    {
+      "q": "The first term of a geometric sequence is 10, and the second term is 5. What is the fourth term?",
+      "answer": "$\\frac{5}{4}$",
+      "image": ""
+    },
+    {
+      "q": "What is the greatest common divisor of 84 and 126?",
+      "answer": "42",
+      "image": ""
+    },
+    {
+      "q": "Alphonse has $20 more than Bettina, and Bettina has $30 more than Charlie. Together they have $200. How many dollars does Bettina have?",
+      "answer": "70",
+      "image": ""
+    },
+    {
+      "q": "A list of five numbers has an average of 12. If four of the numbers are 10, 15, 7, and 14, what is the fifth number?",
+      "answer": "14",
+      "image": ""
+    },
+    {
+      "q": "Define $a \\clubsuit b = \\frac{a + b}{a - b}$. What is the value of $8 \\clubsuit 6$?",
+      "answer": "7",
+      "image": ""
+    }
+  ]
+}

--- a/original_contest_set_3.json
+++ b/original_contest_set_3.json
@@ -1,0 +1,205 @@
+{
+  "name": "Original Contest Set 3",
+  "problems": [
+    {
+      "q": "How many perfect squares are there between 1 and 1000 (inclusive)?",
+      "answer": "31",
+      "image": ""
+    },
+    {
+      "q": "Simplify: $\\frac{1}{2} - \\Big(\\frac{1}{3} - \\frac{1}{4}\\Big)$. Express your answer as a common fraction.",
+      "answer": "$\\frac{5}{12}$",
+      "image": ""
+    },
+    {
+      "q": "Pipe A can fill a pool in 6 hours, and pipe B can fill the same pool in 12 hours. If both pipes are opened together, how many hours will it take to fill the pool?",
+      "answer": "4",
+      "image": ""
+    },
+    {
+      "q": "What is the largest prime number less than 50?",
+      "answer": "47",
+      "image": ""
+    },
+    {
+      "q": "If $4x - 3 = 5$, what is the value of $8x - 3$?",
+      "answer": "13",
+      "image": ""
+    },
+    {
+      "q": "In a school, $\\frac{1}{2}$ of the students play basketball and $\\frac{1}{3}$ play soccer, and the remaining 6 students play neither. (No student plays both sports.) How many students are in the school?",
+      "answer": "36",
+      "image": ""
+    },
+    {
+      "q": "In how many distinct ways can the letters of the word “FACE” be rearranged?",
+      "answer": "24",
+      "image": ""
+    },
+    {
+      "q": "What is the measure, in degrees, of each interior angle of a regular pentagon?",
+      "answer": "108",
+      "image": ""
+    },
+    {
+      "q": "The sequence $2, 5, 8, 11, \\dots$ continues by adding 3 to get the next term. What is the 20th term of this sequence?",
+      "answer": "59",
+      "image": ""
+    },
+    {
+      "q": "A single card is drawn from a standard 52-card deck. What is the probability that the card drawn is a spade or a heart? Express your answer as a common fraction.",
+      "answer": "$\\frac{1}{2}$",
+      "image": ""
+    },
+    {
+      "q": "What is 15% of 80?",
+      "answer": "12",
+      "image": ""
+    },
+    {
+      "q": "A cube has a surface area of 150 square inches. How many cubic inches is its volume?",
+      "answer": "125",
+      "image": ""
+    },
+    {
+      "q": "In the United States, Thanksgiving falls on the fourth Thursday of November. What is the earliest possible calendar date in November on which Thanksgiving can occur?",
+      "answer": "22",
+      "image": ""
+    },
+    {
+      "q": "What is the minimum number of coins needed to make 65 cents using only quarters, dimes, and nickels?",
+      "answer": "4",
+      "image": ""
+    },
+    {
+      "q": "A 100 mL solution is 30% alcohol by volume. If 50 mL of water is added to the solution, what is the percent alcohol in the new solution?",
+      "answer": "20%",
+      "image": ""
+    },
+    {
+      "q": "In an election with 300 total votes between candidates A and B, candidate A received 60% of the votes. How many votes did candidate B receive?",
+      "answer": "120",
+      "image": ""
+    },
+    {
+      "q": "Let $f(1) = 1$, and for every integer $N > 1$, define $f(N) = f(N - 1) + N$. What is the value of $f(5)$?",
+      "answer": "15",
+      "image": ""
+    },
+    {
+      "q": "A runner runs 5 km in 25 minutes. What is the runner’s average speed in kilometers per hour?",
+      "answer": "12",
+      "image": ""
+    },
+    {
+      "q": "In a survey of 100 people, 60 said they liked tea and 70 said they liked coffee. Each person likes at least one of tea or coffee. How many people like both tea and coffee?",
+      "answer": "30",
+      "image": ""
+    },
+    {
+      "q": "There are 6 points in a plane, with no three of them collinear. How many distinct lines can be drawn through pairs of these points?",
+      "answer": "15",
+      "image": ""
+    },
+    {
+      "q": "What is the sum of all distinct prime factors of 84?",
+      "answer": "12",
+      "image": ""
+    },
+    {
+      "q": "A widget costs $50 if bought individually, or $180 for a pack of 4. How many dollars per widget are saved by buying the pack of 4 instead of four individual purchases?",
+      "answer": "5",
+      "image": ""
+    },
+    {
+      "q": "How many integers are between $\\sqrt[4]{50}$ and $\\sqrt[4]{50000}$?",
+      "answer": "12",
+      "image": ""
+    },
+    {
+      "q": "Evaluate $(1 \\times 1!) + (2 \\times 2!) + (3 \\times 3!) + (4 \\times 4!)$.",
+      "answer": "119",
+      "image": ""
+    },
+    {
+      "q": "If $x + y = 8$ and $x - y = 2$, what is the value of $x$?",
+      "answer": "5",
+      "image": ""
+    },
+    {
+      "q": "If a two-digit number is subtracted from the number obtained by reversing its digits, the result is 36. What is the positive difference between the two digits of this number?",
+      "answer": "4",
+      "image": ""
+    },
+    {
+      "q": "If $x^2 = 5$, what is the value of $x^4 + x^2$?",
+      "answer": "30",
+      "image": ""
+    },
+    {
+      "q": "The legs of a right triangle are 5 units and 12 units in length. How many units long is the hypotenuse of the triangle?",
+      "answer": "13",
+      "image": ""
+    },
+    {
+      "q": "If $a:b = 3:4$ and $b:c = 5:6$, what is $a:c$?",
+      "answer": "$5:8$",
+      "image": ""
+    },
+    {
+      "q": "Two fair six-sided dice are rolled. What is the probability that both dice show the same number? Express your answer as a common fraction.",
+      "answer": "$\\frac{1}{6}$",
+      "image": ""
+    },
+    {
+      "q": "What is the smallest perfect square greater than 1 that can be expressed as the sum of two other perfect squares?",
+      "answer": "25",
+      "image": ""
+    },
+    {
+      "q": "If $3^{3^2} = 27^n$, what is the value of $n$?",
+      "answer": "3",
+      "image": ""
+    },
+    {
+      "q": "In an arithmetic sequence, the third term is 15 and the seventh term is 27. What is the common difference of the sequence?",
+      "answer": "3",
+      "image": ""
+    },
+    {
+      "q": "A worker’s salary is increased by 10%, and later it is increased by another 10%. By what percentage has the salary increased overall from the original salary?",
+      "answer": "21%",
+      "image": ""
+    },
+    {
+      "q": "How many integers $n$ satisfy $-2 < n < 5$?",
+      "answer": "6",
+      "image": ""
+    },
+    {
+      "q": "In a geometric sequence, the second term is 6 and the fifth term is 162. What is the common ratio of this sequence?",
+      "answer": "3",
+      "image": ""
+    },
+    {
+      "q": "What is the product of the greatest common divisor and the least common multiple of 18 and 24?",
+      "answer": "432",
+      "image": ""
+    },
+    {
+      "q": "Alice and Bob share a prize of $100 in the ratio $2:3$. How many dollars does Bob receive?",
+      "answer": "60",
+      "image": ""
+    },
+    {
+      "q": "What is the median of the numbers $7, 2, 9,$ and $4$?",
+      "answer": "5.5",
+      "image": ""
+    },
+    {
+      "q": "Define $a \\oplus b = \\frac{a}{b} + \\frac{b}{a}$. What is the value of $2 \\oplus 8$? Express your answer as a common fraction.",
+      "answer": "$\\frac{17}{4}$",
+      "image": ""
+    }
+  ]
+}

--- a/question_bank.json
+++ b/question_bank.json
@@ -2,6 +2,9 @@
   "sets": [
     "default_set.json",
     "linear_equations.json",
-    "fractions.json"
+    "fractions.json",
+    "original_contest_set_1.json",
+    "original_contest_set_2.json",
+    "original_contest_set_3.json"
   ]
 }


### PR DESCRIPTION
## Summary
- add Original Contest Sets 1–3 containing curated problem lists
- reference new contest sets in question_bank.json

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ab215784832687104fd6f763552d